### PR TITLE
docs: CLAUDE.mdにgit worktreeワークフローを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,25 +106,33 @@ idobata/
 
 ## Git Worktree ワークフロー
 
-**⚠️ CRITICAL: 変更作業は必ず git worktree を作成してから開始すること。メインのリポジトリディレクトリ（`/home/mtane0412/dev/idobata`）では直接変更を行わない。**
+**⚠️ CRITICAL: 変更作業は必ず git worktree を作成してから開始すること。メインのリポジトリディレクトリ（`<repo-root>`）では直接変更を行わない。**
 
 ### 目的
 
 - mainブランチを常にクリーンに保つ
 - 作業の分離と並列作業を容易にする
 
+### ブランチ命名規則
+
+- `feature/xxx` - 新機能の追加
+- `fix/xxx` - バグ修正
+- `docs/xxx` - ドキュメントのみの変更
+- `refactor/xxx` - リファクタリング
+- `test/xxx` - テストの追加・修正
+
 ### Worktree 作成手順
 
 ```bash
-# 1. worktreeを作成（ブランチ命名規則は @rules/git-workflow.md に従う）
+# 1. worktreeを作成
 git worktree add ../idobata-<branch-name> -b <branch-name>
 
-# 2. settings.local.jsonをコピー（権限設定のため必須）
+# 2. settings.local.jsonをコピー（権限設定のため必須、ファイルがない場合はスキップ）
 mkdir -p ../idobata-<branch-name>/.claude
-cp .claude/settings.local.json ../idobata-<branch-name>/.claude/
+cp .claude/settings.local.json ../idobata-<branch-name>/.claude/ 2>/dev/null || true
 
-# 3. .envをコピー（環境変数の引き継ぎ）
-cp .env ../idobata-<branch-name>/
+# 3. .envをコピー（環境変数の引き継ぎ、なければ .env.template から作成）
+[ -f .env ] && cp .env ../idobata-<branch-name>/ || echo ".env がないため .env.template から作成してください: cp .env.template .env"
 
 # 4. 依存パッケージをインストール
 cd ../idobata-<branch-name> && npm ci
@@ -133,7 +141,7 @@ cd ../idobata-<branch-name> && npm ci
 ### Worktree 削除手順（作業完了・マージ後）
 
 ```bash
-cd /home/mtane0412/dev/idobata
+cd <repo-root>
 git worktree remove ../idobata-<branch-name>
 ```
 


### PR DESCRIPTION
## Summary

- idobataプロジェクト固有のルールとして、変更作業時にgit worktreeの作成を必須化
- mainブランチを常にクリーンに保ち、作業の分離と並列作業を容易にする目的を明記
- worktree作成・削除の具体的な手順（settings.local.json・.envのコピー、npm ciを含む）を記載

## Test plan

- [ ] CLAUDE.mdの内容が正しく表示されること
- [ ] worktree作成コマンドが実際に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメンテーション**
  * Git Worktree ワークフローに関する新セクションを追加しました。重要な警告、目的、ブランチ命名ルール、ワークツリーの作成・削除手順を明記しています。
  * 環境設定や Docker Compose の利用に関するガイダンスと、依存インストールの推奨手順を追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->