### PR TITLE
fix: AIチャットのPC表示時の文字サイズを改善

### DIFF
--- a/frontend/src/components/chat/common/ChatSheet.tsx
+++ b/frontend/src/components/chat/common/ChatSheet.tsx
@@ -148,7 +148,7 @@ export const ChatSheet: React.FC<ChatSheetProps> = ({
                     <Button
                       variant="outline"
                       size="sm"
-                      className="text-gray-600 border-gray-300 hover:bg-gray-50 rounded-full px-3 py-1 text-xs h-7 font-medium"
+                      className="text-gray-600 border-gray-300 hover:bg-gray-50 rounded-full px-3 py-1 text-xs xl:text-sm h-7 xl:h-8 font-medium"
                       onClick={() => onSendMessage?.("テーマを変える")}
                     >
                       テーマを変える
@@ -156,7 +156,7 @@ export const ChatSheet: React.FC<ChatSheetProps> = ({
                     <Button
                       variant="outline"
                       size="sm"
-                      className="text-gray-600 border-gray-300 hover:bg-gray-50 rounded-full px-3 py-1 text-xs h-7 font-medium"
+                      className="text-gray-600 border-gray-300 hover:bg-gray-50 rounded-full px-3 py-1 text-xs xl:text-sm h-7 xl:h-8 font-medium"
                       onClick={() => onSendMessage?.("対話を終わる")}
                     >
                       対話を終わる

--- a/frontend/src/components/chat/common/ExtendedChatHistory.tsx
+++ b/frontend/src/components/chat/common/ExtendedChatHistory.tsx
@@ -28,7 +28,7 @@ function ExtendedChatHistory({ messages }: ExtendedChatHistoryProps) {
   );
 
   return (
-    <div className="flex-grow px-3 py-2 overflow-y-auto space-y-2 custom-scrollbar">
+    <div className="flex-grow px-3 py-2 xl:px-4 xl:py-3 overflow-y-auto space-y-2 xl:space-y-3 custom-scrollbar">
       {sortedMessages.map((msg, index) => (
         <div
           key={`${msg.createdAt.toISOString()}-${index}`}
@@ -46,16 +46,19 @@ function ExtendedChatHistory({ messages }: ExtendedChatHistoryProps) {
             })}
           >
             <div
-              className={cn("inline-block py-2 px-3 break-words", {
-                "bg-white border border-gray-200 text-gray-800 rounded-2xl rounded-tr-sm":
-                  msg instanceof UserMessage,
-                "bg-white border border-gray-200 text-gray-800 rounded-2xl rounded-tl-sm":
-                  msg instanceof SystemMessage,
-                "bg-gray-100 border border-gray-200 text-gray-700 rounded-2xl":
-                  msg instanceof SystemNotification,
-              })}
+              className={cn(
+                "inline-block py-2 px-3 xl:py-3 xl:px-4 break-words",
+                {
+                  "bg-white border border-gray-200 text-gray-800 rounded-2xl rounded-tr-sm":
+                    msg instanceof UserMessage,
+                  "bg-white border border-gray-200 text-gray-800 rounded-2xl rounded-tl-sm":
+                    msg instanceof SystemMessage,
+                  "bg-gray-100 border border-gray-200 text-gray-700 rounded-2xl":
+                    msg instanceof SystemNotification,
+                }
+              )}
             >
-              <div className="text-sm whitespace-pre-wrap leading-tight">
+              <div className="text-sm xl:text-base whitespace-pre-wrap leading-tight xl:leading-normal">
                 {msg.isStreaming ? (
                   <StreamingText content={msg.content} />
                 ) : (

--- a/frontend/src/components/chat/common/StreamingText.tsx
+++ b/frontend/src/components/chat/common/StreamingText.tsx
@@ -28,7 +28,7 @@ export const StreamingText: React.FC<StreamingTextProps> = ({
     <>
       {displayedText}
       {currentIndex < content.length && (
-        <span className="inline-block w-2 h-4 bg-current opacity-75 animate-pulse" />
+        <span className="inline-block w-2 h-4 xl:w-2.5 xl:h-5 bg-current opacity-75 animate-pulse" />
       )}
     </>
   );


### PR DESCRIPTION
## Summary

- `xl:` ブレークポイント(1280px)を使用してPC表示時のチャット文字サイズを改善
- メッセージ本文: 14px(`text-sm`) → 16px(`xl:text-base`)、行間 1.25 → 1.5
- バブルパディング: `py-2 px-3` → `xl:py-3 xl:px-4`
- メッセージ間隔: `space-y-2` → `xl:space-y-3`
- クイックアクションボタン: `text-xs h-7` → `xl:text-sm xl:h-8`
- ストリーミングカーソル: `w-2 h-4` → `xl:w-2.5 xl:h-5`

モバイル表示(1280px未満)には影響なし。

## Test plan

- [ ] `npm run lint && npm run typecheck && npm run test` がすべてパスすること（確認済み）
- [ ] PCブラウザ(≥1280px)でチャットメッセージの文字サイズが16pxに拡大されていること
- [ ] 行間・バブルパディング・ボタンサイズが文字サイズに合って読みやすくなっていること
- [ ] ブラウザ幅を1280px未満に縮めてモバイル表示に影響がないことを確認

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## スタイル
* 大型ディスプレイでのレスポンシブ UI 改善
  * ボタンのテキストサイズと高さが最適化されました
  * チャットメッセージのパディングとスペーシングが改善されました
  * メッセージテキストのサイズと行高が調整されました
  * ローディングインジケーターのサイズが微調整されました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->