### PR TITLE
docs: worktreeワークフローをブランチ切り替え運用に変更

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,16 +119,24 @@ idobata/
 ### 作業手順
 
 ```bash
-# 1. mainを最新化
-git pull origin main
+# 1. mainに移動して最新化
+git switch main
+git pull --ff-only origin main
 
-# 2. featureブランチを作成して切り替え
-git checkout -b feature/your-feature-name
+# 2. 種別に応じたブランチを作成して切り替え
+git checkout -b <type>/your-change-name
+# 例: git checkout -b feature/add-login
+#     git checkout -b fix/typo
+#     git checkout -b docs/update-workflow
 
-# 3. 作業・コミット・push
-git push -u origin feature/your-feature-name
+# 3. 作業・コミット
+git add <modified-files>
+git commit -m "種別: 変更内容の説明"
 
-# 4. PRを作成
+# 4. push
+git push -u origin <type>/your-change-name
+
+# 5. PRを作成
 gh pr create
 ```
 


### PR DESCRIPTION
## Summary

- `CLAUDE.md` の「Git Worktree ワークフロー」セクションを「Git ブランチワークフロー」セクションに置き換え
- worktreeへの言及をすべて削除し、通常の `git checkout -b` によるブランチ切り替え運用に変更

## 変更理由

git worktreeを使用すると以下の問題が発生するため廃止：
- Docker Compose named volumeがディレクトリ名ベースで別々になり、MongoDBのデータ（テーマ・意見等）が空になる
- Docker構成の固定`container_name`・固定ポートとworktreeの相性が悪い

## Test plan

- [ ] CLAUDE.mdにworktreeへの言及がないことを確認
- [ ] ブランチ命名規則が `~/.claude/rules/git-workflow.md` と一致していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Git ワークフローを「Git ブランチワークフロー」に名称変更しました。
  * main ブランチへの直接コミットを禁止し、フィーチャーブランチ作成と PR 経由でのマージを必須化しました。
  * 作業手順を簡潔化し、ブランチ作成→コミット/プッシュ→PR の流れを強調しました。
  * 環境コピーや並行作業の個別セットアップ手順は削除しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->