### PR TITLE
fix: deploy.ymlのnpm ciをnpm installに戻す

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-      - run: npm ci
+      - run: npm install
       - name: check
         run: npm run check
 


### PR DESCRIPTION
## Summary

- `deploy.yml` の `check` ジョブで `npm ci` が `package-lock.json` を認識できず失敗していた
- `check.yml` と同様の `npm install` に統一する

## 原因

`npm ci` はCI環境でモノレポのワークスペース構成を検出した際に `package-lock.json` を見つけられないケースがある。`check.yml` は `npm install` で正常動作しているため、`deploy.yml` も同じにする。

## Test plan

- [ ] mainへのマージ後、`deploy.yml` の `check` ジョブが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **チョア**
  * CI/CDパイプラインの依存関係インストール処理を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->