### PR TITLE
fix: admin/frontendのDockerfileからpackage-lock.jsonのCOPYを削除

### DIFF
--- a/admin/Dockerfile.prod
+++ b/admin/Dockerfile.prod
@@ -7,9 +7,9 @@
 FROM node:20-alpine AS builder
 WORKDIR /app
 
-COPY package.json package-lock.json ./
-# ci コマンドで package-lock.json に基づく再現性の高いインストールを行う
-RUN npm ci
+COPY package.json ./
+# ワークスペース個別のpackage-lock.jsonはないためnpm installを使用
+RUN npm install
 
 COPY . .
 RUN npm run build

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -7,9 +7,9 @@
 FROM node:20-alpine AS builder
 WORKDIR /app
 
-COPY package.json package-lock.json ./
-# ci コマンドで package-lock.json に基づく再現性の高いインストールを行う
-RUN npm ci
+COPY package.json ./
+# ワークスペース個別のpackage-lock.jsonはないためnpm installを使用
+RUN npm install
 
 COPY . .
 RUN npm run build


### PR DESCRIPTION
## Summary

- `admin/Dockerfile.prod` と `frontend/Dockerfile.prod` で `COPY package.json package-lock.json ./` + `npm ci` が失敗していた
- npmワークスペース構成では `package-lock.json` はルートのみ存在し、各ワークスペースのビルドコンテキスト（`./admin`, `./frontend`）には含まれない
- `package.json` のみCOPYし、`npm install` を使用するよう修正

## 根本原因

`.gitignore` に `*/**/package-lock.json` が設定されており、各ワークスペースのロックファイルはgit管理外。
GHCRビルド時のコンテキストはサブディレクトリのため、ルートの `package-lock.json` を参照できない。

## Test plan

- [ ] mainへのマージ後、`deploy.yml` の `build-and-push` ジョブ（admin, frontend）が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* 管理画面とフロントエンドのビルドプロセスを更新しました。パッケージインストール方法をnpm ciからnpm installに変更し、ワークスペース固有のロックファイルへの依存を削除することで、ビルドの柔軟性を向上させています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->