### PR TITLE
fix: appleboy/scp-actionを廃止しnative scp/sshに置き換え

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,9 +113,11 @@ jobs:
   #                     MITM攻撃を防ぐため、事前に取得してシークレットに固定する
   #
   # VPS側の事前準備:
-  #   GHCR_PAT は /proc/<pid>/cmdline 漏洩を防ぐためコマンドライン引数で渡さない
-  #   VPS上の ~/.ghcr_pat にread:packagesスコープのPATを事前配置すること:
-  #     echo "YOUR_GHCR_PAT" > ~/.ghcr_pat && chmod 600 ~/.ghcr_pat
+  #   1. GHCR_PAT: /proc/<pid>/cmdline 漏洩を防ぐためコマンドライン引数で渡さない
+  #      read:packagesスコープのPATを事前配置すること:
+  #        echo "YOUR_GHCR_PAT" > ~/.ghcr_pat && chmod 600 ~/.ghcr_pat
+  #   2. .env.prod: docker compose で使用する本番環境変数ファイルを配置すること:
+  #        ~/idobata/.env.prod（適切なパーミッション推奨: chmod 600）
   deploy:
     needs: build-and-push
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- `appleboy/scp-action` と `appleboy/ssh-action` を廃止し、native `scp` / `ssh` コマンドに置き換え

## 根本原因

`appleboy/scp-action` は内部で複数のSSH接続を張る（アップロード用・コマンド実行用・クリーンアップ用）。2回目以降の接続が `i/o timeout` で失敗し、デプロイが継続的に失敗していた。

## 変更内容

`deploy` ジョブの steps を以下のように変更：

1. **SSH鍵のセットアップ**（新規）: `ssh-keyscan` でknown_hostsを生成
2. **設定ファイルをVPSへ転送**: `scp-action` → native `scp` コマンド（1接続）
3. **VPSでデプロイ実行**: `ssh-action` → native `ssh` + heredoc（1接続）

## Test plan

- [ ] mainへのマージ後、`deploy.yml` の `deploy` ジョブが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * デプロイワークフローを統合・最適化し、SSH鍵と接続設定の取り扱いを明確化して信頼性を向上しました。
  * 構成ファイルの一括転送をエンコード方式へ変更し、リモート適用を簡素化しました。
  * ワークフローで利用するシークレットを見直し、サーバー側でのパーソナルアクセストークン管理（GHCR_PATの移行）と既知ホスト情報の追加を反映しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->