### PR TITLE
fix: cfut_プレフィックスのCloudflare APIトークンに対応

### DIFF
--- a/Dockerfile.caddy
+++ b/Dockerfile.caddy
@@ -4,11 +4,16 @@
 
 FROM caddy:2-builder AS builder
 
-# Cloudflare DNS plugin reference (commit SHA / tag / version).
-# NOTE:
-# - Pinned to a specific commit to ensure reproducible builds and avoid unexpected upstream changes.
-# - When updating: change this to a newer tag or commit after verifying compatibility.
-# - Consider unpinning or moving to a stable tag once upstream behavior is confirmed stable.
+# caddy-dns/cloudflare の参照先コミット
+#
+# 出典: 公式リポジトリ github.com/caddy-dns/cloudflare の未マージ PR #123
+#   https://github.com/caddy-dns/cloudflare/pull/123
+#   コミット: 1bc23c92a08e0c38937c6cc28b461722471e78b9（2026-03-18, Oleg German）
+#   内容: cfut_/cfat_ プレフィックスの新形式 Cloudflare API トークンを受け入れる修正
+#   確認: 公式リポジトリで HTTP 200 確認済み（フォークではなく公式リポジトリのコミット）
+#
+# 最新リリース v0.2.3（6dc1fbb7, 2025-12-04）はこの修正を含まないため暫定固定。
+# PR がマージされ公式リリースに含まれた時点で ARG を削除し latest タグへ戻すこと。
 ARG CLOUDFLARE_DNS_CLOUDFLARE_REF=1bc23c92a08e0c38937c6cc28b461722471e78b9
 
 RUN xcaddy build \


### PR DESCRIPTION
## 背景

`caddy-dns/cloudflare` プラグインが、Cloudflareの新しいトークン形式（`cfut_` プレフィックス）を検証時に不正と判断してCaddyが起動できない問題が発生していた。

```
provision dns.providers.cloudflare: API token 'cfut_...' appears invalid
```

## 原因

`caddy-dns/cloudflare` プラグインのトークン形式バリデーションが旧形式のみを許可しており、Cloudflareが新たに導入した `cfut_`（User API Token）・`cfat_`（Account API Token）プレフィックスのトークンを拒否していた。

参考: `https://github.com/caddy-dns/cloudflare/pull/123`

## 修正内容

`Dockerfile.caddy` で `--with github.com/caddy-dns/cloudflare` をビルドする際に、`cfut_` トークン対応のコミット（`1bc23c92`）を明示的に指定するよう変更。

```dockerfile
xcaddy build \
    --with github.com/caddy-dns/cloudflare@1bc23c92a08e0c38937c6cc28b461722471e78b9
```

当該PRがマージ・リリースされた後は、バージョン固定を解除する予定。

## テスト方法

1. このPRをマージ後、GitHub ActionsでCaddyイメージが再ビルドされる
2. VPSでコンテナを再起動し、`docker logs caddy-prod` でエラーが出ないことを確認
3. `https://<DOMAIN>/health` が `200 OK` を返すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Cloudflare DNSプラグインの取得を固定化し、ビルド時に参照バージョンを指定できるようにしてビルドの再現性と安定性を向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->