### PR TITLE
fix: xcaddyでフォークを参照しcfut_トークンビルドエラーを修正

### DIFF
--- a/Dockerfile.caddy
+++ b/Dockerfile.caddy
@@ -14,7 +14,7 @@ FROM caddy:2-builder AS builder
 # 【参照先】
 #   フォーク:  github.com/ogerman/cloudflare（master ブランチ = PR #123 の修正コミット）
 #   コミット:  1bc23c92a08e0c38937c6cc28b461722471e78b9（2026-03-18, ogerman）
-#   公式 PR:   https://github.com/caddy-dns/cloudflare/pull/123
+#   公式 PR:   caddy-dns/cloudflare PR #123（cfut_/cfat_ トークン形式対応）
 #
 # 【切り戻し手順】
 #   公式 PR #123 がマージされ新バージョンがリリースされたら以下を実施すること:


### PR DESCRIPTION
## 問題

PR #27 でコミット SHA `1bc23c92` を直接指定したが、Go モジュールプロキシは `refs/pull/*` を解決できないためビルドが失敗していた。

```
[FATAL] exit status 1
xcaddy build --with github.com/caddy-dns/cloudflare@${CLOUDFLARE_DNS_CLOUDFLARE_REF}
```

## 原因

Go の `go get <module>@<commit-sha>` は、そのコミットが標準的な git ref（branch/tag）から到達可能でない場合、モジュールプロキシが解決できない。

## 修正

xcaddy の `original=fork@commit` 構文を使用して、PR 著者（ogerman）のフォークを参照するよう変更。

```dockerfile
xcaddy build \
    --with github.com/caddy-dns/cloudflare=github.com/ogerman/cloudflare@1bc23c92a08e0c38937c6cc28b461722471e78b9
```

- フォーク: github.com/ogerman/cloudflare（`master` ブランチ先端 = 修正コミット）
- この構文は go.mod の `replace` ディレクティブに相当し、モジュールパスは `github.com/caddy-dns/cloudflare` のまま保持される

## 今後の対応

caddy-dns/cloudflare の新バージョンリリース後、`ARG CLOUDFLARE_DNS_CLOUDFLARE_REF` を公式タグに戻すこと。

🤖 Generated with [Claude Code](https://claude.com/claude-code)