### PR TITLE
fix: Express 5のpath-to-regexpワイルドカード構文エラーを修正

### DIFF
--- a/idea-discussion/backend/server.js
+++ b/idea-discussion/backend/server.js
@@ -123,7 +123,7 @@ if (process.env.NODE_ENV === "production") {
   app.use(express.static(frontendBuildPath));
 
   // For any request that doesn't match an API route, serve the React app
-  app.get("*", (req, res) => {
+  app.get("/{*path}", (req, res) => {
     res.sendFile(path.join(frontendBuildPath, "index.html"));
   });
 }


### PR DESCRIPTION
## 問題

本番環境でバックエンドが起動直後にクラッシュしていた。

```
PathError [TypeError]: Missing parameter name at index 1: *
    at new Layer (/app/node_modules/router/lib/layer.js:93:62)
```

## 原因

Express 5 + path-to-regexp v8 では `app.get('*', ...)` の `*` ワイルドカード構文がサポート外になった。

## 修正

```js
// Before
app.get("*", (req, res) => { ... })

// After
app.get("/{*path}", (req, res) => { ... })
```

`/{*path}` は Express 5 / path-to-regexp v8 で推奨されるキャッチオールパターン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)