### PR TITLE
fix: /adminアクセス時の404を修正（/admin/へリダイレクト）

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -46,6 +46,8 @@ www.{$DOMAIN} {
     # 管理画面（/admin/ プレフィックスを除去してプロキシ）
     # admin アプリは vite base: '/admin/' でビルドされているため
     # ブラウザからは /admin/assets/... でアセットが参照される
+    # /admin（スラッシュなし）は /admin/ へリダイレクト
+    redir /admin /admin/ permanent
     handle_path /admin/* {
         reverse_proxy admin-prod:80
     }


### PR DESCRIPTION
## 問題

`/admin`（末尾スラッシュなし）にアクセスすると404になっていた。

## 原因

`handle_path /admin/*` は `/admin/`（スラッシュあり）以降にマッチするが、`/admin` そのものにはマッチしない。そのためフロントエンドのSPAにフォールバックし、React Routerが`/admin`ルートを持たないため404になっていた。

## 修正

`redir /admin /admin/ permanent` を追加してトレイリングスラッシュを補完。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 管理ページへのアクセスで、末尾のスラッシュなし (`/admin`) からスラッシュあり (`/admin/`) への自動リダイレクトが追加されました。URL の一貫性が改善されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->