### PR TITLE
fix: admin本番DockerfileにVITE_API_BASE_URLビルド引数を追加

### DIFF
--- a/admin/Dockerfile.prod
+++ b/admin/Dockerfile.prod
@@ -12,6 +12,12 @@ COPY package.json package-lock.json ./
 RUN npm ci
 
 COPY . .
+
+# adminのAPIはCaddyが /api/idea/* → idea-backend-prod:3100 にプロキシする
+# frontend/Dockerfile.prod と同じ設定を使用する
+ARG VITE_API_BASE_URL=/api/idea
+ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
+
 RUN npm run build
 
 # Stage 2: 配信ステージ


### PR DESCRIPTION
## 概要

本番環境で管理者セットアップページ（`/admin/setup`）にリダイレクトされない問題を修正します。

## 原因

`admin/Dockerfile.prod` にビルド時の `VITE_API_BASE_URL` が設定されていなかったため、ビルドされたアプリ内で `import.meta.env.VITE_API_BASE_URL` が `undefined` になっていました。

その結果:
- APIクライアントの `baseUrl` が `undefined/api` となる
- `GET undefined/api/auth/setup-status` のリクエストが失敗する
- `Login.tsx` のエラーハンドリングで `setNeedsSetup(false)` が実行される
- セットアップページへのリダイレクトが発動せず、ログインフォームが表示される

## 修正内容

`frontend/Dockerfile.prod`（20-21行目）と同様に、`ARG VITE_API_BASE_URL=/api/idea` を追加しました。

admin画面もfrontendと同じバックエンド（idea-discussion/backend）を使用するため、同じ `/api/idea` をベースURLとします。

## リクエストフロー

- ブラウザ: `GET /api/idea/api/auth/setup-status`
- Caddy除去後: `GET /api/auth/setup-status`
- バックエンドマッチ: `/api/auth` → `setup-status`

## テスト方法

- [ ] Dockerイメージをビルドし、ビルド成果物に `/api/idea` が埋め込まれていることを確認
- [ ] 本番デプロイ後、管理画面（`/admin/`）アクセス時にセットアップページへリダイレクトされることを確認
- [ ] DevToolsのNetworkで `GET /api/idea/api/auth/setup-status` が200で返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)