### PR TITLE
refactor: middleware・workersのTypeScript移行 (PR-C, Issue #46)

### DIFF
--- a/idea-discussion/backend/middleware/authMiddleware.ts
+++ b/idea-discussion/backend/middleware/authMiddleware.ts
@@ -1,12 +1,27 @@
+/**
+ * 認証ミドルウェア
+ *
+ * 目的: JWT トークンを検証し、req.user に認証済みユーザー情報を設定する。
+ * 注意: protect は必須認証（未認証時 401 を返す）。
+ *       admin は管理者権限チェック（admin 以外は 403）。
+ *       optionalProtect はトークンがない・無効でもエラーにせず next() を呼ぶ。
+ */
+
+import type { NextFunction, Request, Response } from "express";
 import AdminUser from "../models/AdminUser.js";
 import authService from "../services/auth/authService.js";
 
-export const protect = async (req, res, next) => {
+export const protect = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
   try {
     const authHeader = req.headers.authorization;
 
     if (!authHeader || !authHeader.startsWith("Bearer ")) {
-      return res.status(401).json({ message: "認証が必要です" });
+      res.status(401).json({ message: "認証が必要です" });
+      return;
     }
 
     const token = authHeader.split(" ")[1];
@@ -17,7 +32,8 @@ export const protect = async (req, res, next) => {
       const user = await AdminUser.findById(decoded.id);
 
       if (!user) {
-        return res.status(401).json({ message: "ユーザーが見つかりません" });
+        res.status(401).json({ message: "ユーザーが見つかりません" });
+        return;
       }
 
       req.user = {
@@ -27,8 +43,8 @@ export const protect = async (req, res, next) => {
       };
 
       next();
-    } catch (error) {
-      return res.status(401).json({ message: "トークンが無効です" });
+    } catch {
+      res.status(401).json({ message: "トークンが無効です" });
     }
   } catch (error) {
     console.error("[AuthMiddleware] Protect error:", error);
@@ -36,7 +52,11 @@ export const protect = async (req, res, next) => {
   }
 };
 
-export const admin = (req, res, next) => {
+export const admin = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void => {
   if (req.user && req.user.role === "admin") {
     next();
   } else {
@@ -49,12 +69,17 @@ export const admin = (req, res, next) => {
  * トークンがない・無効でもエラーにせず next() を呼ぶ任意認証ミドルウェア。
  * 公開エンドポイントで管理者権限に応じて挙動を変えたい場合に使用する。
  */
-export const optionalProtect = async (req, res, next) => {
+export const optionalProtect = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
   try {
     const authHeader = req.headers.authorization;
 
     if (!authHeader || !authHeader.startsWith("Bearer ")) {
-      return next();
+      next();
+      return;
     }
 
     const token = authHeader.split(" ")[1];

--- a/idea-discussion/backend/middleware/uploadMiddleware.ts
+++ b/idea-discussion/backend/middleware/uploadMiddleware.ts
@@ -1,6 +1,16 @@
+/**
+ * ファイルアップロードミドルウェア
+ *
+ * 目的: multer を使用した画像ファイルのアップロード処理を提供する。
+ * 注意: 対応形式は JPEG・PNG・GIF のみ。最大ファイルサイズは 5MB。
+ *       一時保存先は uploads/temp ディレクトリ。
+ *       @types/multer は未インストールのため、ファイルオブジェクトは最小限の型で定義する。
+ */
+
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import type { NextFunction, Request, Response } from "express";
 import multer from "multer";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -11,7 +21,11 @@ if (!fs.existsSync(tempDir)) {
   fs.mkdirSync(tempDir, { recursive: true });
 }
 
-export const logRequest = (req, res, next) => {
+export const logRequest = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void => {
   console.log("Request headers:", req.headers);
   console.log("Request method:", req.method);
   console.log("Request URL:", req.url);
@@ -19,22 +33,39 @@ export const logRequest = (req, res, next) => {
   next();
 };
 
+/** multer ファイルオブジェクトの最小限の型定義 */
+interface UploadFile {
+  fieldname: string;
+  originalname: string;
+  mimetype: string;
+}
+
 const storage = multer.diskStorage({
   destination: (req, file, cb) => {
-    console.log("Multer destination called with file:", file.originalname);
+    console.log(
+      "Multer destination called with file:",
+      (file as UploadFile).originalname
+    );
     cb(null, tempDir);
   },
   filename: (req, file, cb) => {
-    console.log("Multer filename called with file:", file.originalname);
+    console.log(
+      "Multer filename called with file:",
+      (file as UploadFile).originalname
+    );
     const uniqueSuffix = `${Date.now()}-${Math.round(Math.random() * 1e9)}`;
     cb(
       null,
-      `${file.fieldname}-${uniqueSuffix}${path.extname(file.originalname)}`
+      `${(file as UploadFile).fieldname}-${uniqueSuffix}${path.extname((file as UploadFile).originalname)}`
     );
   },
 });
 
-const fileFilter = (req, file, cb) => {
+const fileFilter = (
+  req: Request,
+  file: UploadFile,
+  cb: (error: Error | null, accept?: boolean) => void
+): void => {
   console.log("Multer fileFilter called with file:", file);
   const allowedTypes = ["image/jpeg", "image/png", "image/gif"];
 
@@ -56,6 +87,6 @@ const limits = {
 
 export const upload = multer({
   storage: storage,
-  fileFilter: fileFilter,
+  fileFilter: fileFilter as multer.Options["fileFilter"],
   limits: limits,
 });

--- a/idea-discussion/backend/types/express.d.ts
+++ b/idea-discussion/backend/types/express.d.ts
@@ -1,0 +1,15 @@
+/**
+ * Express Request 型拡張
+ *
+ * 目的: req.user の型定義を追加し、認証ミドルウェアで設定されるユーザー情報を型安全に参照できるようにする。
+ */
+
+declare namespace Express {
+  interface Request {
+    user?: {
+      id: unknown;
+      email: string;
+      role: string;
+    };
+  }
+}

--- a/idea-discussion/backend/workers/debateAnalysisGenerator.ts
+++ b/idea-discussion/backend/workers/debateAnalysisGenerator.ts
@@ -1,6 +1,14 @@
+/**
+ * 論点分析生成ワーカー
+ *
+ * 目的: サービス層の generateDebateAnalysis をジョブキューから呼び出す薄いラッパー。
+ */
+
 import { generateDebateAnalysis } from "../services/debateAnalysisGenerator.js";
 
-export async function generateDebateAnalysisTask(questionId) {
+export async function generateDebateAnalysisTask(
+  questionId: string
+): Promise<object | undefined> {
   try {
     console.log(
       `[Worker] Starting debate analysis generation for questionId: ${questionId}`

--- a/idea-discussion/backend/workers/digestGenerator.ts
+++ b/idea-discussion/backend/workers/digestGenerator.ts
@@ -1,3 +1,10 @@
+/**
+ * ダイジェスト生成ワーカー
+ *
+ * 目的: 政策ドラフトをもとに一般市民向けの読みやすいダイジェストを生成し、DB に保存する。
+ * 注意: 最新の政策ドラフトが存在しない場合は生成をスキップする。
+ */
+
 import DigestDraft from "../models/DigestDraft.js";
 import PolicyDraft from "../models/PolicyDraft.js";
 import Problem from "../models/Problem.js";
@@ -6,7 +13,13 @@ import SharpQuestion from "../models/SharpQuestion.js";
 import Solution from "../models/Solution.js";
 import { callLLM } from "../services/llmService.js";
 
-async function generateDigestDraft(questionId) {
+/** ダイジェスト生成 LLM レスポンスの型 */
+interface DigestLLMResponse {
+  title?: string;
+  content?: string;
+}
+
+async function generateDigestDraft(questionId: string): Promise<void> {
   console.log(
     `[DigestGenerator] Starting digest draft generation for questionId: ${questionId}`
   );
@@ -39,27 +52,19 @@ async function generateDigestDraft(questionId) {
     const problemIds = problemLinks.map((link) => link.linkedItemId);
     const solutionIds = solutionLinks.map((link) => link.linkedItemId);
 
-    const relevanceScoreMap = new Map();
-    for (const link of links) {
-      relevanceScoreMap.set(
-        link.linkedItemId.toString(),
-        link.relevanceScore || 0
-      );
-    }
-
     const problems = await Problem.find({ _id: { $in: problemIds } });
     const solutions = await Solution.find({ _id: { $in: solutionIds } });
 
     const sortedProblems = problemIds
       .map((id) => problems.find((p) => p._id.toString() === id.toString()))
-      .filter(Boolean); // Remove any undefined values
+      .filter(Boolean);
 
     const sortedSolutions = solutionIds
       .map((id) => solutions.find((s) => s._id.toString() === id.toString()))
-      .filter(Boolean); // Remove any undefined values
+      .filter(Boolean);
 
-    const problemStatements = sortedProblems.map((p) => p.statement);
-    const solutionStatements = sortedSolutions.map((s) => s.statement);
+    const problemStatements = sortedProblems.map((p) => p?.statement);
+    const solutionStatements = sortedSolutions.map((s) => s?.statement);
 
     console.log(
       `[DigestGenerator] Found ${problemStatements.length} related problems and ${solutionStatements.length} related solutions, sorted by relevance.`
@@ -83,7 +88,7 @@ async function generateDigestDraft(questionId) {
 
     const messages = [
       {
-        role: "system",
+        role: "system" as const,
         content: `あなたはAIアシスタントです。あなたの任務は、中心的な重要論点（「私たちはどのようにして...できるか？」）、その重要論点に関連する問題点と解決策、そして政策ドラフトを分析し、一般市民向けに読みやすく噛み砕いたダイジェストを作成することです。
 
 あなたの出力は、'title'（文字列）と'content'（文字列）のキーを含むJSONオブジェクトにする必要があります。
@@ -113,7 +118,7 @@ async function generateDigestDraft(questionId) {
 応答は、"title"（文字列、ダイジェスト全体に適したタイトル）と "content"（文字列、Markdownで適切にフォーマットされた内容）のキーを含むJSONオブジェクトのみで行ってください。JSON構造外に他のテキストや説明を含めないでください。`,
       },
       {
-        role: "user",
+        role: "user" as const,
         content: `Generate a digest for the following:
 
 Question: ${question.questionText}
@@ -133,11 +138,11 @@ Please provide the output as a JSON object with "title" and "content" keys. The 
     ];
 
     console.log("[DigestGenerator] Calling LLM to generate digest draft...");
-    const llmResponse = await callLLM(
+    const llmResponse = (await callLLM(
       messages,
       true,
       "google/gemini-2.5-pro-preview-03-25"
-    ); // Request JSON output with specific model
+    )) as DigestLLMResponse;
 
     if (
       !llmResponse ||

--- a/idea-discussion/backend/workers/extractionWorker.ts
+++ b/idea-discussion/backend/workers/extractionWorker.ts
@@ -1,19 +1,74 @@
-import ChatThread from "../models/ChatThread.js"; // For chat source
-import ImportedItem from "../models/ImportedItem.js"; // For import source
+/**
+ * 抽出ワーカー
+ *
+ * 目的: チャット会話またはインポートテキストから課題（Problem）と解決策（Solution）を LLM で抽出し、
+ *       DB に保存してリンキングをトリガーする。
+ * 注意: チャット抽出は additions（新規）と updates（既存更新）の両方を処理する。
+ *       インポート抽出は additions のみを処理し、ImportedItem のステータスを更新する。
+ *       動的モデル選択（Problem/Solution）は typeof Problem | typeof Solution で型付け。
+ */
+
+import type { Types } from "mongoose";
+import ChatThread from "../models/ChatThread.js";
+import ImportedItem from "../models/ImportedItem.js";
 import Problem from "../models/Problem.js";
 import Solution from "../models/Solution.js";
 import { callLLM } from "../services/llmService.js";
 import { resolveStageConfig } from "../services/pipelineConfigService.js";
-import { emitNewExtraction } from "../services/socketService.js"; // Import socket service
-import { linkItemToQuestions } from "./linkingWorker.js"; // Assume this function exists and works
+import { emitNewExtraction } from "../services/socketService.js";
+import { linkItemToQuestions } from "./linkingWorker.js";
+
+/** 抽出アイテムの型（additions 配列の要素） */
+interface ExtractionItem {
+  type: "problem" | "solution";
+  statement: string;
+}
+
+/** 更新アイテムの型（updates 配列の要素） */
+interface UpdateItem {
+  id: string;
+  type: "problem" | "solution";
+  statement: string;
+}
+
+/** チャット抽出 LLM レスポンスの型 */
+interface ChatExtractionResponse {
+  additions?: ExtractionItem[];
+  updates?: UpdateItem[];
+}
+
+/** インポート抽出 LLM レスポンスの型 */
+interface ImportExtractionResponse {
+  additions?: ExtractionItem[];
+}
+
+/** ジョブデータの型 */
+interface ExtractionJobData {
+  sourceType: string;
+  sourceOriginId: string;
+  content?: string;
+  metadata?: object;
+  themeId?: string;
+}
 
 // Helper function to build the prompt based on source type
-function buildExtractionPrompt(sourceType, data) {
+function buildExtractionPrompt(
+  sourceType: string,
+  data: {
+    messages?: Array<{ role: string; content: string }>;
+    existingProblems?: Array<{ _id: unknown; statement: string }>;
+    existingSolutions?: Array<{ _id: unknown; statement: string }>;
+    content?: string;
+  }
+): Array<{ role: "user" | "assistant" | "system"; content: string }> {
   let prompt = "";
 
   if (sourceType === "chat") {
-    const { messages, existingProblems, existingSolutions } = data;
-    // Prepare conversation history string
+    const {
+      messages = [],
+      existingProblems = [],
+      existingSolutions = [],
+    } = data;
     // Find the latest user message index
     const latestUserIndex = [...messages]
       .reverse()
@@ -136,7 +191,7 @@ Output Format: Respond ONLY in JSON format with the following structure:
     sourceType === "other_import" ||
     sourceType !== "chat"
   ) {
-    const { content } = data;
+    const { content = "" } = data;
     // Construct the prompt for single text import
     prompt = `
 Input Text:
@@ -199,19 +254,23 @@ Output Format: Respond ONLY in JSON format with the following structure:
 `;
   }
 
-  // Return messages array for LLM
   return [{ role: "user", content: prompt }];
+}
+
+/** 保存済みドキュメントの最小型定義 */
+interface SavedDocument {
+  _id: unknown;
 }
 
 // Helper to save a new problem/solution and trigger linking
 async function saveAndLinkItem(
-  itemData,
-  sourceOriginId,
-  sourceType,
-  sourceMetadata,
-  themeId
-) {
-  let savedItem;
+  itemData: ExtractionItem,
+  sourceOriginId: string,
+  sourceType: string,
+  sourceMetadata: object,
+  themeId: Types.ObjectId | string
+): Promise<SavedDocument | null> {
+  let savedItem: SavedDocument | null = null;
   if (itemData.type === "problem") {
     const newProblem = new Problem({
       statement: itemData.statement,
@@ -243,7 +302,7 @@ async function saveAndLinkItem(
   if (savedItem) {
     // Trigger linking asynchronously
     setTimeout(
-      () => linkItemToQuestions(savedItem._id.toString(), itemData.type),
+      () => linkItemToQuestions(String(savedItem._id), itemData.type),
       0
     );
     return savedItem;
@@ -252,17 +311,17 @@ async function saveAndLinkItem(
 }
 
 // Main processing function called by the job queue worker
-async function processExtraction(job) {
-  const { sourceType, sourceOriginId, content, metadata, themeId } = job.data; // Assuming job data structure
+async function processExtraction(job: {
+  data: ExtractionJobData;
+}): Promise<void> {
+  const { sourceType, sourceOriginId } = job.data;
   console.log(
     `[ExtractionWorker] Starting extraction for ${sourceType}: ${sourceOriginId}`
   );
-  // Transaction removed as it requires a replica set/mongos
 
   try {
-    let llmResponse;
-    const addedProblemIds = [];
-    const addedSolutionIds = [];
+    const addedProblemIds: unknown[] = [];
+    const addedSolutionIds: unknown[] = [];
 
     if (sourceType === "chat") {
       // --- Chat Processing Logic ---
@@ -271,7 +330,7 @@ async function processExtraction(job) {
         console.error(
           `[ExtractionWorker] ChatThread not found: ${sourceOriginId}`
         );
-        return; // Or throw error for queue retry
+        return;
       }
 
       const existingProblemIds = thread.extractedProblemIds || [];
@@ -293,11 +352,11 @@ async function processExtraction(job) {
         thread.themeId.toString(),
         "extraction_chat"
       );
-      llmResponse = await callLLM(
+      const llmResponse = (await callLLM(
         extractionPromptMessages,
         true,
         chatExtractionModel
-      ); // Request JSON
+      )) as ChatExtractionResponse;
 
       if (
         !llmResponse ||
@@ -308,7 +367,7 @@ async function processExtraction(job) {
           `[ExtractionWorker] LLM did not return valid JSON or expected structure for chat ${sourceOriginId}. Response:`,
           llmResponse
         );
-        return; // Or throw error
+        return;
       }
 
       const additions = llmResponse.additions || [];
@@ -331,12 +390,12 @@ async function processExtraction(job) {
           "chat",
           {},
           thread.themeId
-        ); // Pass themeId from thread
+        );
         if (savedItem) {
           if (item.type === "problem") {
             addedProblemIds.push(savedItem._id);
             emitNewExtraction(
-              thread.themeId,
+              thread.themeId.toString(),
               sourceOriginId,
               "problem",
               savedItem
@@ -345,7 +404,7 @@ async function processExtraction(job) {
           if (item.type === "solution") {
             addedSolutionIds.push(savedItem._id);
             emitNewExtraction(
-              thread.themeId,
+              thread.themeId.toString(),
               sourceOriginId,
               "solution",
               savedItem
@@ -372,12 +431,13 @@ async function processExtraction(job) {
           );
           continue;
         }
-        const updateData = { ...item };
+        const updateData: Record<string, unknown> = { ...item };
         updateData.id = undefined;
         updateData.type = undefined;
         updateData.version = undefined; // Let $inc handle version
 
-        let Model;
+        // 動的モデル選択: typeof Problem | typeof Solution で型付け
+        let Model: typeof Problem | typeof Solution;
         if (item.type === "problem") Model = Problem;
         else if (item.type === "solution") Model = Solution;
         else continue;
@@ -402,7 +462,7 @@ async function processExtraction(job) {
           setTimeout(
             () => linkItemToQuestions(item.id.toString(), item.type),
             0
-          ); // Trigger linking for updates too
+          );
         } else {
           console.warn(
             `[ExtractionWorker] Failed to update ${item.type} ${item.id} (chat ${sourceOriginId}). Version mismatch or not found.`
@@ -436,7 +496,7 @@ async function processExtraction(job) {
         console.error(
           `[ExtractionWorker] ImportedItem not found: ${sourceOriginId}`
         );
-        return; // Or throw error
+        return;
       }
       if (importItem.status !== "pending") {
         console.warn(
@@ -458,11 +518,11 @@ async function processExtraction(job) {
         importItem.themeId.toString(),
         "extraction_import"
       );
-      llmResponse = await callLLM(
+      const llmResponse = (await callLLM(
         extractionPromptMessages,
         true,
         importExtractionModel
-      ); // Request JSON
+      )) as ImportExtractionResponse;
 
       if (
         !llmResponse ||
@@ -476,7 +536,7 @@ async function processExtraction(job) {
         importItem.status = "failed";
         importItem.errorMessage = "LLM response invalid";
         await importItem.save();
-        return; // Or throw error
+        return;
       }
 
       const additions = llmResponse.additions || [];
@@ -492,7 +552,6 @@ async function processExtraction(job) {
         console.log(
           `[ExtractionWorker] Processing item ${i + 1}/${totalAdditions} (${item.type}) for ${sourceType} ${sourceOriginId}`
         );
-        // Use the metadata from the job/importItem and pass themeId
         const savedItem = await saveAndLinkItem(
           item,
           sourceOriginId,
@@ -504,7 +563,7 @@ async function processExtraction(job) {
           if (item.type === "problem") {
             addedProblemIds.push(savedItem._id);
             emitNewExtraction(
-              importItem.themeId,
+              importItem.themeId.toString(),
               sourceOriginId,
               "problem",
               savedItem
@@ -513,7 +572,7 @@ async function processExtraction(job) {
           if (item.type === "solution") {
             addedSolutionIds.push(savedItem._id);
             emitNewExtraction(
-              importItem.themeId,
+              importItem.themeId.toString(),
               sourceOriginId,
               "solution",
               savedItem
@@ -524,10 +583,10 @@ async function processExtraction(job) {
 
       // 4. Update ImportedItem status and IDs
       importItem.status = "completed";
-      importItem.extractedProblemIds = addedProblemIds;
-      importItem.extractedSolutionIds = addedSolutionIds;
+      importItem.extractedProblemIds = addedProblemIds as Types.ObjectId[];
+      importItem.extractedSolutionIds = addedSolutionIds as Types.ObjectId[];
       importItem.processedAt = new Date();
-      importItem.errorMessage = undefined; // Clear previous error if any
+      importItem.errorMessage = undefined;
       await importItem.save();
       console.log(
         `[ExtractionWorker] Updated imported item ${sourceOriginId} with status 'completed' and extraction IDs.`
@@ -552,11 +611,12 @@ async function processExtraction(job) {
     ) {
       try {
         await ImportedItem.updateOne(
-          { _id: sourceOriginId, status: "processing" }, // Only update if still processing
+          { _id: sourceOriginId, status: "processing" },
           {
             $set: {
               status: "failed",
-              errorMessage: error.message || "Unknown error",
+              errorMessage:
+                error instanceof Error ? error.message : "Unknown error",
             },
           }
         );
@@ -567,120 +627,7 @@ async function processExtraction(job) {
         );
       }
     }
-    // Rethrow the error if the job queue supports retries
-    // throw error;
   }
 }
 
-// Export the main processing function
 export { processExtraction };
-
-/*
-// --- Old Chat-Specific Logic (kept for reference during refactoring, remove later) ---
-
-async function processExtraction_OLD(threadId) {
-    console.log(`[ExtractionWorker] Starting extraction for thread: ${threadId}`);
-    // Transaction removed as it requires a replica set/mongos
-
-    try {
-        // 1. Fetch thread and existing extractions within the transaction
-        const thread = await ChatThread.findById(threadId); // Removed .session(session)
-        if (!thread) {
-            console.error(`[ExtractionWorker] Thread not found: ${threadId}`);
-            // Removed transaction abort/end
-            return;
-        }
-
-        const existingProblemIds = thread.extractedProblemIds || [];
-        const existingSolutionIds = thread.extractedSolutionIds || [];
-
-        const [existingProblems, existingSolutions] = await Promise.all([
-            Problem.find({ '_id': { $in: existingProblemIds } }), // Removed .session(session)
-            Solution.find({ '_id': { $in: existingSolutionIds } }) // Removed .session(session)
-        ]);
-
-        // 2. Build prompt and call LLM
-        const extractionPromptMessages = buildExtractionPrompt_OLD(thread.messages, existingProblems, existingSolutions);
-        const llmResponse = await callLLM(extractionPromptMessages, true); // Request JSON output
-
-        if (!llmResponse || typeof llmResponse !== 'object' || (!llmResponse.additions && !llmResponse.updates)) {
-            console.warn(`[ExtractionWorker] LLM did not return valid JSON or expected structure for thread ${threadId}. Response:`, llmResponse);
-            // Removed transaction abort/end
-            return;
-        }
-
-
-        const additions = llmResponse.additions || [];
-        const updates = llmResponse.updates || [];
-        const addedProblemIds = [];
-        const addedSolutionIds = [];
-
-        // 3. Process additions
-        for (const item of additions) {
-             const savedItem = await saveAndLinkItem(item, threadId, 'chat', {}); // Use helper
-             if (savedItem) {
-                 if (item.type === 'problem') addedProblemIds.push(savedItem._id);
-                 if (item.type === 'solution') addedSolutionIds.push(savedItem._id);
-             }
-        }
-
-        // 4. Process updates
-         for (const item of updates) {
-             if (!item.id) {
-                console.warn(`[ExtractionWorker] Invalid update item received from LLM for thread ${threadId}:`, item);
-                continue;
-            }
-            const updateData = { ...item };
-            delete updateData.id;
-            delete updateData.type;
-            delete updateData.version; // Let $inc handle version
-
-            let Model, existingItem;
-            if (item.type === 'problem') Model = Problem;
-            else if (item.type === 'solution') Model = Solution;
-            else continue;
-
-            existingItem = await Model.findById(item.id);
-            if (!existingItem) {
-                 console.warn(`[ExtractionWorker] ${item.type} ${item.id} not found for update (thread ${threadId}).`);
-                 continue;
-            }
-
-            const result = await Model.findOneAndUpdate(
-                { _id: item.id, version: existingItem.version },
-                { $set: updateData, $inc: { version: 1 } },
-                { new: true }
-            );
-            if (result) {
-                console.log(`[ExtractionWorker] Updated ${item.type}: ${item.id} to version ${result.version} (thread ${threadId})`);
-                setTimeout(() => linkItemToQuestions(item.id.toString(), item.type), 0); // Trigger linking for updates too
-            } else {
-                console.warn(`[ExtractionWorker] Failed to update ${item.type} ${item.id} (thread ${threadId}). Version mismatch or not found.`);
-            }
-        }
-
-        // 5. Update ChatThread with new IDs (if any)
-        if (addedProblemIds.length > 0 || addedSolutionIds.length > 0) {
-            await ChatThread.updateOne(
-                { _id: threadId },
-                {
-                    $addToSet: {
-                        extractedProblemIds: { $each: addedProblemIds },
-                        extractedSolutionIds: { $each: addedSolutionIds },
-                    },
-                }
-            );
-            console.log(`[ExtractionWorker] Updated thread ${threadId} with new extraction IDs.`);
-        }
-
-        // Transaction removed
-        console.log(`[ExtractionWorker] Successfully processed extraction for thread: ${threadId}`);
-
-    } catch (error) {
-        console.error(`[ExtractionWorker] Error processing extraction for thread ${threadId}:`, error);
-        // Transaction removed
-        // Consider adding retry logic or moving to a dead-letter queue here
-    }
-    // Linking is triggered within the loop now
-}
-*/

--- a/idea-discussion/backend/workers/linkingWorker.ts
+++ b/idea-discussion/backend/workers/linkingWorker.ts
@@ -7,6 +7,7 @@
  *       内部で DB 取得後に _executeLinking を呼ぶ。
  */
 
+import type { Types } from "mongoose";
 import pLimit from "p-limit";
 import Problem from "../models/Problem.js";
 import QuestionLink from "../models/QuestionLink.js";
@@ -16,32 +17,41 @@ import { callLLM } from "../services/llmService.js";
 import { resolveStageConfig } from "../services/pipelineConfigService.js";
 import { emitExtractionUpdate } from "../services/socketService.js";
 
-const DEFAULT_CONCURRENCY_LIMIT = 10; // Set the concurrency limit here
+const DEFAULT_CONCURRENCY_LIMIT = 10;
+
+/** リンキング判定 LLM レスポンスの型 */
+interface LinkingLLMResponse {
+  is_relevant?: boolean;
+  link_type?: string;
+  relevanceScore?: number;
+  rationale?: string;
+}
+
+/** リンキング対象アイテムの最小限の型 */
+interface LinkableItem {
+  _id: unknown;
+  statement: string;
+  themeId?: Types.ObjectId;
+}
 
 /**
  * LLM 呼び出しと QuestionLink 保存のみを行う内部ヘルパー。
  * DB アクセスは行わず、呼び出し元で取得済みのオブジェクトを受け取る。
- *
- * @param {object} question - SharpQuestion ドキュメント
- * @param {object} item - Problem または Solution ドキュメント
- * @param {'problem' | 'solution'} itemType - アイテム種別
- * @param {string} linkingModel - 使用するモデル名
- * @param {string} linkingPrompt - システムプロンプト
  */
 async function _executeLinking(
-  question,
-  item,
-  itemType,
-  linkingModel,
-  linkingPrompt
-) {
+  question: { _id: unknown; questionText: string },
+  item: LinkableItem,
+  itemType: "problem" | "solution",
+  linkingModel: string,
+  linkingPrompt: string
+): Promise<void> {
   const promptMessages = [
     {
-      role: "system",
+      role: "system" as const,
       content: linkingPrompt,
     },
     {
-      role: "user",
+      role: "user" as const,
       content: `Sharp Question: "${question.questionText}"
 
 Statement (${itemType}): "${item.statement}"
@@ -51,7 +61,11 @@ Analyze the relationship and provide the JSON output.`,
   ];
 
   try {
-    const llmResponse = await callLLM(promptMessages, true, linkingModel);
+    const llmResponse = (await callLLM(
+      promptMessages,
+      true,
+      linkingModel
+    )) as LinkingLLMResponse;
 
     if (llmResponse?.is_relevant) {
       console.log(
@@ -80,13 +94,16 @@ Analyze the relationship and provide the JSON output.`,
 
 /**
  * Links a specific Problem or Solution item to relevant SharpQuestions using LLM.
- * @param {string} itemId - The ID of the Problem or Solution item.
- * @param {'problem' | 'solution'} itemType - The type of the item ('problem' or 'solution').
+ * @param itemId - The ID of the Problem or Solution item.
+ * @param itemType - The type of the item ('problem' or 'solution').
  */
-async function linkItemToQuestions(itemId, itemType) {
+async function linkItemToQuestions(
+  itemId: string,
+  itemType: "problem" | "solution"
+): Promise<void> {
   console.log(`[LinkingWorker] Starting linking for ${itemType} ID: ${itemId}`);
   try {
-    let item;
+    let item: LinkableItem | null;
     if (itemType === "problem") {
       item = await Problem.findById(itemId);
     } else if (itemType === "solution") {
@@ -146,7 +163,7 @@ async function linkItemToQuestions(itemId, itemType) {
       `[LinkingWorker] Finished linking for ${itemType} ID: ${itemId}`
     );
 
-    emitExtractionUpdate(itemThemeId, null, itemType, item);
+    emitExtractionUpdate(itemThemeId.toString(), null, itemType, item);
   } catch (error) {
     console.error(
       `[LinkingWorker] Error processing linking for ${itemType} ID ${itemId}:`,
@@ -157,11 +174,15 @@ async function linkItemToQuestions(itemId, itemType) {
 
 /**
  * Links a specific SharpQuestion to a specific Problem or Solution item using LLM.
- * @param {string} questionId - The ID of the SharpQuestion.
- * @param {string} itemId - The ID of the Problem or Solution item.
- * @param {'problem' | 'solution'} itemType - The type of the item ('problem' or 'solution').
+ * @param questionId - The ID of the SharpQuestion.
+ * @param itemId - The ID of the Problem or Solution item.
+ * @param itemType - The type of the item ('problem' or 'solution').
  */
-async function linkSpecificQuestionToItem(questionId, itemId, itemType) {
+async function linkSpecificQuestionToItem(
+  questionId: string,
+  itemId: string,
+  itemType: "problem" | "solution"
+): Promise<void> {
   try {
     const question = await SharpQuestion.findById(questionId);
     if (!question) {
@@ -171,7 +192,7 @@ async function linkSpecificQuestionToItem(questionId, itemId, itemType) {
       return;
     }
 
-    let item;
+    let item: LinkableItem | null;
     if (itemType === "problem") {
       item = await Problem.findById(itemId);
     } else if (itemType === "solution") {
@@ -222,9 +243,9 @@ async function linkSpecificQuestionToItem(questionId, itemId, itemType) {
 /**
  * Links all existing Problems and Solutions to a specific SharpQuestion.
  * Typically called after a new question is generated.
- * @param {string} questionId - The ID of the newly generated SharpQuestion.
+ * @param questionId - The ID of the newly generated SharpQuestion.
  */
-async function linkQuestionToAllItems(questionId) {
+async function linkQuestionToAllItems(questionId: string): Promise<void> {
   const concurrencyLimit = DEFAULT_CONCURRENCY_LIMIT;
   console.log(
     `[LinkingWorker] Starting linking for new Question ID: ${questionId} with concurrency ${concurrencyLimit}`
@@ -263,7 +284,7 @@ async function linkQuestionToAllItems(questionId) {
       `[LinkingWorker] Linking Question ${questionId} to ${problems.length} problems and ${solutions.length} solutions from theme ${themeId}. Total tasks: ${totalTasks}`
     );
 
-    const tasks = [];
+    const tasks: Promise<void>[] = [];
 
     for (const problem of problems) {
       tasks.push(
@@ -271,7 +292,7 @@ async function linkQuestionToAllItems(questionId) {
           try {
             await _executeLinking(
               question,
-              problem,
+              problem as LinkableItem,
               "problem",
               linkingModel,
               linkingPrompt
@@ -296,7 +317,7 @@ async function linkQuestionToAllItems(questionId) {
           try {
             await _executeLinking(
               question,
-              solution,
+              solution as LinkableItem,
               "solution",
               linkingModel,
               linkingPrompt

--- a/idea-discussion/backend/workers/policyGenerator.ts
+++ b/idea-discussion/backend/workers/policyGenerator.ts
@@ -1,4 +1,10 @@
-import mongoose from "mongoose";
+/**
+ * 政策ドラフト生成ワーカー
+ *
+ * 目的: 重要論点に関連する課題と解決策から政策ドラフトを生成し、DB に保存する。
+ * 注意: ビジョンレポート（現状認識・理想像）と解決手段レポートの2部構成で生成する。
+ */
+
 import PolicyDraft from "../models/PolicyDraft.js";
 import Problem from "../models/Problem.js";
 import QuestionLink from "../models/QuestionLink.js";
@@ -6,7 +12,13 @@ import SharpQuestion from "../models/SharpQuestion.js";
 import Solution from "../models/Solution.js";
 import { callLLM } from "../services/llmService.js";
 
-async function generatePolicyDraft(questionId) {
+/** 政策ドラフト生成 LLM レスポンスの型 */
+interface PolicyLLMResponse {
+  title?: string;
+  content?: string;
+}
+
+async function generatePolicyDraft(questionId: string): Promise<void> {
   console.log(
     `[PolicyGenerator] Starting policy draft generation for questionId: ${questionId}`
   );
@@ -44,15 +56,6 @@ async function generatePolicyDraft(questionId) {
     const problemIds = problemLinks.map((link) => link.linkedItemId);
     const solutionIds = solutionLinks.map((link) => link.linkedItemId);
 
-    // Create a map of IDs to relevanceScores for later use
-    const relevanceScoreMap = new Map();
-    for (const link of links) {
-      relevanceScoreMap.set(
-        link.linkedItemId.toString(),
-        link.relevanceScore || 0
-      );
-    }
-
     // Fetch problems and solutions
     const problems = await Problem.find({ _id: { $in: problemIds } });
     const solutions = await Solution.find({ _id: { $in: solutionIds } });
@@ -60,15 +63,15 @@ async function generatePolicyDraft(questionId) {
     // Sort problems and solutions according to the order of IDs (which are already sorted by relevanceScore)
     const sortedProblems = problemIds
       .map((id) => problems.find((p) => p._id.toString() === id.toString()))
-      .filter(Boolean); // Remove any undefined values
+      .filter(Boolean);
 
     const sortedSolutions = solutionIds
       .map((id) => solutions.find((s) => s._id.toString() === id.toString()))
-      .filter(Boolean); // Remove any undefined values
+      .filter(Boolean);
 
     // Map to statements with relevance scores
-    const problemStatements = sortedProblems.map((p) => p.statement);
-    const solutionStatements = sortedSolutions.map((s) => s.statement);
+    const problemStatements = sortedProblems.map((p) => p?.statement);
+    const solutionStatements = sortedSolutions.map((s) => s?.statement);
 
     console.log(
       `[PolicyGenerator] Found ${problemStatements.length} related problems and ${solutionStatements.length} related solutions, sorted by relevance.`
@@ -77,7 +80,7 @@ async function generatePolicyDraft(questionId) {
     // 3. Prepare the prompt for LLM
     const messages = [
       {
-        role: "system",
+        role: "system" as const,
         content: `あなたはAIアシスタントです。中心的な重要論点（「私たちはどのようにして...できるか？」）、関連する問題点のリスト、そして市民からの意見を通じて特定された潜在的な解決策のリストに基づいて、政策文書を作成する任務を負っています。
 あなたの出力は、'content'フィールド内に明確に2つのパートで構成されなければなりません。
 
@@ -105,7 +108,7 @@ Part 2: 解決手段レポート
 応答は、"title"（文字列、文書全体に適したタイトル）と "content"（文字列、'ビジョンレポート'と'解決手段レポート'の両セクションを含み、Markdownヘッダー（例：## ビジョンレポート、## 解決手段レポート）などを使用して明確に区切られ、フォーマットされたもの）のキーを含むJSONオブジェクトのみで行ってください。JSON構造外に他のテキストや説明を含めないでください。`,
       },
       {
-        role: "user",
+        role: "user" as const,
         content: `Generate a report for the following question:
 Question: ${question.questionText}
 
@@ -121,11 +124,11 @@ Please provide the output as a JSON object with "title" and "content" keys. When
 
     // 4. Call LLM
     console.log("[PolicyGenerator] Calling LLM to generate policy draft...");
-    const llmResponse = await callLLM(
+    const llmResponse = (await callLLM(
       messages,
       true,
       "google/gemini-2.5-pro-preview-03-25"
-    ); // Request JSON output with specific model
+    )) as PolicyLLMResponse;
 
     if (
       !llmResponse ||
@@ -165,7 +168,6 @@ Please provide the output as a JSON object with "title" and "content" keys. When
       `[PolicyGenerator] Error generating policy draft for questionId ${questionId}:`,
       error
     );
-    // Add more robust error handling/reporting if needed
   }
 }
 

--- a/idea-discussion/backend/workers/questionGenerator.ts
+++ b/idea-discussion/backend/workers/questionGenerator.ts
@@ -1,10 +1,24 @@
+/**
+ * 重要論点生成ワーカー
+ *
+ * 目的: テーマの課題一覧から LLM を使用して HMW 形式の重要論点を生成し、DB に保存する。
+ * 注意: 生成後、各論点に対して linkQuestionToAllItems を非同期でトリガーする。
+ */
+
 import Problem from "../models/Problem.js";
 import SharpQuestion from "../models/SharpQuestion.js";
 import { callLLM } from "../services/llmService.js";
 import { resolveStageConfig } from "../services/pipelineConfigService.js";
-import { linkQuestionToAllItems } from "./linkingWorker.js"; // Import the linking function
+import { linkQuestionToAllItems } from "./linkingWorker.js";
 
-async function generateSharpQuestions(themeId) {
+/** LLM が返す重要論点オブジェクトの型 */
+interface GeneratedQuestionObject {
+  question: string;
+  tagLine?: string;
+  tags?: string[];
+}
+
+async function generateSharpQuestions(themeId: string): Promise<void> {
   console.log(
     `[QuestionGenerator] Starting sharp question generation for theme ${themeId}...`
   );
@@ -28,18 +42,20 @@ async function generateSharpQuestions(themeId) {
 
     const messages = [
       {
-        role: "system",
+        role: "system" as const,
         content: questionPrompt,
       },
       {
-        role: "user",
+        role: "user" as const,
         content: `Based on the following problem statements, please generate relevant questions in Japanese using the format "How Might We...":\n\n${problemStatements.join("\n- ")}\n\nFor each question, clearly describe both the current state ("現状はこう") and the desired state ("それをこうしたい") with high detail. Focus exclusively on describing these states without suggesting any specific means, methods, or solutions that could narrow the range of possible answers.\n\nPlease provide the output as a JSON object containing a "questions" array, where each element is an object with "question", "tagLine", and "tags" keys.`,
       },
     ];
 
     // 3. Call LLM
     console.log("[QuestionGenerator] Calling LLM to generate questions...");
-    const llmResponse = await callLLM(messages, true, questionModel); // Request JSON output with specific model
+    const llmResponse = (await callLLM(messages, true, questionModel)) as {
+      questions?: GeneratedQuestionObject[];
+    };
 
     if (
       !llmResponse ||
@@ -93,22 +109,13 @@ async function generateSharpQuestions(themeId) {
           } // Create if not exists, return the new doc
         );
 
-        // Check if it was an upsert (a new document was created)
-        // The result object will contain the _id. If upserted:true is in the result, it's new.
-        // A simpler check might be to compare createdAt with a time just before the loop,
-        // but checking the result object structure or comparing timestamps is more robust.
-        // For simplicity, let's assume if we get a result, we trigger linking.
-        // A more precise check would involve comparing timestamps or checking the upserted flag if available in the result.
         if (result?._id) {
           // Trigger linking asynchronously for the new or existing question
-          // Linking all items to this question might be resource-intensive.
-          // Consider triggering only if it's a truly *new* question.
-          // For now, trigger it regardless, as per the simplified approach.
           console.log(
             `[QuestionGenerator] Triggering linking for question ID: ${result._id}`
           );
           setTimeout(() => linkQuestionToAllItems(result._id.toString()), 0);
-          savedCount++; // Count successfully processed questions
+          savedCount++;
         } else {
           console.warn(
             `[QuestionGenerator] Failed to save or find question: ${questionText}`
@@ -125,7 +132,6 @@ async function generateSharpQuestions(themeId) {
     console.log(
       `[QuestionGenerator] Successfully processed ${savedCount} questions (new or existing).`
     );
-    // Linking is now triggered after each question is saved/upserted above.
   } catch (error) {
     console.error(
       "[QuestionGenerator] Error during sharp question generation:",

--- a/idea-discussion/backend/workers/reportGenerator.ts
+++ b/idea-discussion/backend/workers/reportGenerator.ts
@@ -1,4 +1,10 @@
-import mongoose from "mongoose";
+/**
+ * レポート生成ワーカー
+ *
+ * 目的: 重要論点に関連する課題と解決策から市民向けレポートを生成し、DB に保存する。
+ * 注意: レポートは上書きせずに版を重ねて保存する。
+ */
+
 import Problem from "../models/Problem.js";
 import QuestionLink from "../models/QuestionLink.js";
 import ReportExample from "../models/ReportExample.js";
@@ -7,7 +13,13 @@ import Solution from "../models/Solution.js";
 import { callLLM } from "../services/llmService.js";
 import { resolveStageConfig } from "../services/pipelineConfigService.js";
 
-async function generateReportExample(questionId) {
+/** レポート生成 LLM レスポンスの型 */
+interface ReportLLMResponse {
+  introduction?: string;
+  issues?: Array<{ title: string; description: string }>;
+}
+
+async function generateReportExample(questionId: string): Promise<void> {
   console.log(
     `[ReportGenerator] Starting report example generation for questionId: ${questionId}`
   );
@@ -51,8 +63,8 @@ async function generateReportExample(questionId) {
       .map((id) => solutions.find((s) => s._id.toString() === id.toString()))
       .filter(Boolean);
 
-    const problemStatements = sortedProblems.map((p) => p.statement);
-    const solutionStatements = sortedSolutions.map((s) => s.statement);
+    const problemStatements = sortedProblems.map((p) => p?.statement);
+    const solutionStatements = sortedSolutions.map((s) => s?.statement);
 
     console.log(
       `[ReportGenerator] Found ${problemStatements.length} related problems and ${solutionStatements.length} related solutions, sorted by relevance.`
@@ -60,7 +72,7 @@ async function generateReportExample(questionId) {
 
     const messages = [
       {
-        role: "system",
+        role: "system" as const,
         content: `重要論点「${question.questionText}」について、市民からの意見を通じて特定された問題点とその潜在的な解決策を含むレポートを作成してください。
 
 レポートは、以下の形式で出力してください：
@@ -90,7 +102,7 @@ async function generateReportExample(questionId) {
 JSON構造外に他のテキストや説明を含めないでください。`,
       },
       {
-        role: "user",
+        role: "user" as const,
         content: `Generate a report example for the following question:
 Question: ${question.questionText}
 
@@ -115,7 +127,11 @@ Please provide the output as a JSON object with "introduction" and "issues" keys
     const { model: reportModel } = await resolveStageConfig(themeId, "report");
 
     console.log("[ReportGenerator] Calling LLM to generate report example...");
-    const llmResponse = await callLLM(messages, true, reportModel);
+    const llmResponse = (await callLLM(
+      messages,
+      true,
+      reportModel
+    )) as ReportLLMResponse;
 
     if (
       !llmResponse ||

--- a/idea-discussion/backend/workers/visualReportGenerator.ts
+++ b/idea-discussion/backend/workers/visualReportGenerator.ts
@@ -1,6 +1,12 @@
+/**
+ * ビジュアルレポート生成ワーカー
+ *
+ * 目的: サービス層の generateQuestionVisualReport をジョブキューから呼び出す薄いラッパー。
+ */
+
 import { generateQuestionVisualReport } from "../services/questionVisualReportGenerator.js";
 
-async function generateVisualReport(questionId) {
+async function generateVisualReport(questionId: string): Promise<void> {
   console.log(
     `[VisualReportWorker] Starting visual report generation for questionId: ${questionId}`
   );


### PR DESCRIPTION
## Summary

Issue #46 TypeScript完全移行 PR-C：フェーズ4前半（middleware + workers 11ファイル）

- `types/express.d.ts` 追加: `req.user` 型定義（`id: unknown`, `email: string`, `role: string`）
- `middleware/authMiddleware.js` → `.ts`: `Request`/`Response`/`NextFunction` 型付け
- `middleware/uploadMiddleware.js` → `.ts`: multerラッパー型付け（`@types/multer` 未使用のため最小限の独自型定義）
- `workers/debateAnalysisGenerator.js` → `.ts`: 薄いラッパー
- `workers/visualReportGenerator.js` → `.ts`: 薄いラッパー
- `workers/questionGenerator.js` → `.ts`: `GeneratedQuestionObject` 型定義
- `workers/reportGenerator.js` → `.ts`: `ReportLLMResponse` 型定義
- `workers/policyGenerator.js` → `.ts`: `PolicyLLMResponse` 型定義
- `workers/digestGenerator.js` → `.ts`: `DigestLLMResponse` 型定義
- `workers/linkingWorker.js` → `.ts`: `LinkableItem`/`LinkingLLMResponse` 型定義、`emitExtractionUpdate` に `.toString()` 追加
- `workers/extractionWorker.js` → `.ts`: `ExtractionItem`/`UpdateItem`/`SavedDocument` 型定義、動的モデル選択を `typeof Problem | typeof Solution` で型付け

## Test plan

- [x] `npm run typecheck` — 型エラーなし
- [x] `npm run lint` — lint警告なし
- [x] `npm test` — 85テスト全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)