### PR TITLE
feat: ThemeDetail画面「寄せられた意見」のリアルタイム反映

### DIFF
--- a/frontend/src/pages/ThemeDetail.tsx
+++ b/frontend/src/pages/ThemeDetail.tsx
@@ -119,37 +119,34 @@ const ThemeDetail = () => {
   };
 
   // レンダーをまたいで安定した参照を維持するためuseCallbackで定義する
-  const handleNewExtraction = useCallback(
-    (extraction: NewExtractionEvent) => {
-      const { type, data } = extraction;
+  const handleNewExtraction = useCallback((extraction: NewExtractionEvent) => {
+    const { type, data } = extraction;
 
-      if (type === "problem") {
-        setOpinions((prev) => {
-          const exists = prev.issues.some((issue) => issue.id === data._id);
-          if (exists) return prev;
-          return {
-            ...prev,
-            issues: [...prev.issues, { id: data._id, text: data.statement }],
-          };
-        });
-      } else if (type === "solution") {
-        setOpinions((prev) => {
-          const exists = prev.solutions.some(
-            (solution) => solution.id === data._id
-          );
-          if (exists) return prev;
-          return {
-            ...prev,
-            solutions: [
-              ...prev.solutions,
-              { id: data._id, text: data.statement },
-            ],
-          };
-        });
-      }
-    },
-    [setOpinions]
-  );
+    if (type === "problem") {
+      setOpinions((prev) => {
+        const exists = prev.issues.some((issue) => issue.id === data._id);
+        if (exists) return prev;
+        return {
+          ...prev,
+          issues: [...prev.issues, { id: data._id, text: data.statement }],
+        };
+      });
+    } else if (type === "solution") {
+      setOpinions((prev) => {
+        const exists = prev.solutions.some(
+          (solution) => solution.id === data._id
+        );
+        if (exists) return prev;
+        return {
+          ...prev,
+          solutions: [
+            ...prev.solutions,
+            { id: data._id, text: data.statement },
+          ],
+        };
+      });
+    }
+  }, []);
 
   useEffect(() => {
     if (!themeId) return;


### PR DESCRIPTION
## Summary

- `ThemeDetail.tsx` に `opinions` ローカルstateを追加し、`new-extraction` WebSocketイベントで issues/solutions をリアルタイム更新
- `QuestionDetail.tsx` と同等のパターンを適用（重複チェック付き）
- `handleNewExtraction` を `useCallback` で安定化し、不要な再購読を防止
- `themeDetail` 取得データの初期化を「空の場合のみ」から「常にマージ（id重複除外）」に改善

## 変更ファイル

- `frontend/src/pages/ThemeDetail.tsx`
  - `opinions` state 追加（issues/solutions）
  - `handleNewExtraction` を `useCallback` で実装（`problem`/`solution` type に応じて state 更新）
  - `themeDetail` 初期化 `useEffect`：WebSocket受信済み項目とマージ（deduplication）
  - WebSocket購読 `useEffect`：`socketClient.subscribeToTheme` + `socketClient.onNewExtraction` 設定
  - `templateProps` の issues/solutions を `opinions` state から参照

## Test plan

- [ ] `npm run typecheck` エラーなし
- [ ] `npm run lint` エラーなし
- [ ] ThemeDetail画面でチャット送信 → 「寄せられた意見」セクションにリアルタイムで課題/解決策が追加される
- [ ] ページリロード後も既存の意見が正しく表示される（themeDetail API取得データが opinions に反映される）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * テーマ詳細ページでリアルタイム受信の購読管理を追加しました（不要時は購読解除）。
  * 受信した課題/解決案をページ側で管理し、表示を即時反映します。
  * 取得済みデータと受信データをマージして欠落分は追加、重複は自動で排除します。
  * テーマ切替時に表示データをリセットします。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->